### PR TITLE
Alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,34 @@
 # syntax=docker/dockerfile:1
 
-FROM ubuntu:jammy
+FROM alpine:3.18 AS builder
+
+RUN set -ex \
+  && apk add --no-cache \
+    build-base \
+    git \
+    autoconf \
+    automake \
+  && cd /tmp \
+  && git clone --depth=1 "https://github.com/samhocevar/rinetd" \
+  && cd rinetd \
+  && ./bootstrap \
+  && ./configure --prefix=/usr \
+  && make -j $(nproc) \
+  && strip rinetd
+
+FROM alpine:3.18
 
 ARG TARGETPLATFORM
 
 LABEL org.opencontainers.image.source=https://github.com/DigitallyRefined/docker-wireguard-tunnel
 LABEL org.opencontainers.image.description="docker-wireguard-tunnel ${TARGETPLATFORM}"
 
-ENV DEBIAN_FRONTEND=noninteractive
-ENV TERM=xterm
+COPY --from=builder /tmp/rinetd/rinetd /usr/sbin/rinetd
 
-RUN \
-  apt update && \
-  apt dist-upgrade -y && \
-  apt install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    ifupdown \
-    iproute2 \
-    iputils-ping \
-    openresolv \
-    rinetd \
-    wireguard-tools && \
-  apt autoremove -y && \
-  rm -rf \
-    /tmp/* \
-    /var/lib/apt/lists/* \
-    /var/tmp/*
+RUN apk add --no-cache wireguard-tools
 
-RUN cp /etc/rinetd.conf /etc/rinetd.conf.ori
+COPY wg-start.sh /usr/sbin/wireguard
 
-COPY wg-start.sh /usr/local/bin/wireguard
-
-CMD ["wireguard"]
+CMD ["/usr/sbin/wireguard"]
 
 EXPOSE 51820/udp


### PR DESCRIPTION
Image size now only 15.4MB down from 105MB. Alpine is great for Docker lightweight images such as this.

Credit to [xiaozhuai](https://github.com/xiaozhuai) for the [`Dockerfile`](https://github.com/xiaozhuai/docker-rinetd-alpine/blob/master/Dockerfile) which shows you how to build rinetd from source on Alpine. This is required because Alpine does not currently include a rinetd package.

I have tested this on a pair of `linux/amd64` machines, I have not noticed any issues.