### PR TITLE
Use newly provided Alpine rinetd package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ LABEL org.opencontainers.image.description="docker-wireguard-tunnel ${TARGETPLAT
 RUN apk upgrade --no-cache
 RUN apk add --no-cache wireguard-tools
 RUN apk add --no-cache rinetd --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN cp /etc/rinetd.conf /etc/rinetd.conf.ori
 
 COPY wg-start.sh /usr/sbin/wg-start.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,5 @@
 # syntax=docker/dockerfile:1
 
-FROM alpine:3.19 AS builder
-
-RUN set -ex \
-  && apk upgrade --no-cache \
-  && apk add --no-cache \
-    build-base \
-    git \
-    autoconf \
-    automake \
-  && cd /tmp \
-  && git clone --depth=1 "https://github.com/samhocevar/rinetd" \
-  && cd rinetd \
-  && ./bootstrap \
-  && ./configure --prefix=/usr \
-  && make -j $(nproc) \
-  && strip rinetd
-
 FROM alpine:3.19
 
 ARG TARGETPLATFORM
@@ -24,11 +7,9 @@ ARG TARGETPLATFORM
 LABEL org.opencontainers.image.source=https://github.com/DigitallyRefined/docker-wireguard-tunnel
 LABEL org.opencontainers.image.description="docker-wireguard-tunnel ${TARGETPLATFORM}"
 
-COPY --from=builder /tmp/rinetd/rinetd /usr/sbin/rinetd
-COPY --from=builder /tmp/rinetd/rinetd.conf /etc/rinetd.conf.ori
-
 RUN apk upgrade --no-cache
 RUN apk add --no-cache wireguard-tools
+RUN apk add --no-cache rinetd --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 COPY wg-start.sh /usr/sbin/wg-start.sh
 

--- a/wg-start.sh
+++ b/wg-start.sh
@@ -46,7 +46,7 @@ EOF
   fi
 fi
 
-cp /etc/rinetd.conf.ori /etc/rinetd.conf
+cp /etc/rinetd.conf
 
 IFS=',' read -ra SERVICE <<<"$SERVICES"
 for serv in "${SERVICE[@]}"; do

--- a/wg-start.sh
+++ b/wg-start.sh
@@ -46,8 +46,6 @@ EOF
   fi
 fi
 
-touch /etc/rinetd.conf
-
 IFS=',' read -ra SERVICE <<<"$SERVICES"
 for serv in "${SERVICE[@]}"; do
   service_parts=(${serv//\:/ })

--- a/wg-start.sh
+++ b/wg-start.sh
@@ -46,6 +46,8 @@ EOF
   fi
 fi
 
+cp /etc/rinetd.conf.ori /etc/rinetd.conf
+
 IFS=',' read -ra SERVICE <<<"$SERVICES"
 for serv in "${SERVICE[@]}"; do
   service_parts=(${serv//\:/ })

--- a/wg-start.sh
+++ b/wg-start.sh
@@ -46,7 +46,7 @@ EOF
   fi
 fi
 
-cp /etc/rinetd.conf
+touch /etc/rinetd.conf
 
 IFS=',' read -ra SERVICE <<<"$SERVICES"
 for serv in "${SERVICE[@]}"; do


### PR DESCRIPTION
A while ago I requested for rinetd to be added to Alpine packages. It was recently added so I have updated the Dockerfile to use the the provided package instead of manually building rinetd.